### PR TITLE
Add global task timer and goal specific timer display

### DIFF
--- a/src/CustomMissionLog.as
+++ b/src/CustomMissionLog.as
@@ -32,7 +32,9 @@ class CustomMissionLog
 
 	public static var fmtDefault: TextFormat;
 	public static var fmtTitle: TextFormat;
+	public static var fmtTaskTimer: TextFormat;
 	public static var fmtGoal: TextFormat;
+	public static var fmtGoalTimer: TextFormat;
 	public static var fmtTypeAction: TextFormat;
 	public static var fmtTypeInvestigation: TextFormat;
 	public static var fmtTypeSabotage: TextFormat;
@@ -146,7 +148,9 @@ class CustomMissionLog
 		// text format
 		fmtDefault = new TextFormat("lib.Aller.ttf", 18, 0xCCCCCC, true, false, false);
 		fmtTitle = new TextFormat("lib.Aller.ttf", 20, 0xFFFFFF, true, false, false);
+		fmtTaskTimer = new TextFormat("lib.Aller.ttf", 20, 0xee2b2b, true, false, false);
 		fmtGoal = new TextFormat("lib.Aller.ttf", 18, 0x63f99a, true, false, false);
+		fmtGoalTimer = new TextFormat("lib.Aller.ttf", 18, 0x08dd56, true, false, false);
 		fmtTypeAction = new TextFormat("lib.Aller.ttf", 18, 0xf04949, true, false, false);
 		fmtTypeInvestigation = new TextFormat("lib.Aller.ttf", 18, 0x54ae16, true, false, false);
 		fmtTypeSabotage = new TextFormat("lib.Aller.ttf", 18, 0xeca603, true, false, false);
@@ -445,6 +449,14 @@ class CustomMissionLog
 	// add mission text to full window text and return it
 	static function addMissionText(text: String, quest: Quest): String
 	{
+		// current task global timer
+		if (quest.m_CurrentTask.m_Timeout > 0)
+		{
+			var timerText:String = timeToString(quest.m_CurrentTask.m_Timeout);
+			addString(text, fmtTaskTimer, timerText);
+			text += timerText  + " ";
+		}
+		
 		// basic mission info
 		var missionType:String = GUI.Mission.MissionUtils.MissionTypeToString(quest.m_MissionType);
 		var tier:String = quest.m_CurrentTask.m_Tier + "/" + quest.m_TierMax;
@@ -455,14 +467,6 @@ class CustomMissionLog
 		text += "<" + missionType + "> [L" +
 			quest.m_CurrentTask.m_Difficulty + "] [" +
 			tier + "]";
-			
-		// current task global timer
-		if (quest.m_CurrentTask.m_Timeout > 0)
-		{
-			var timerText:String = " " + timeToString(quest.m_CurrentTask.m_Timeout);
-			addString(text, fmtDefault, timerText);
-			text += timerText;
-		}
 		
 		text += "\n";
 
@@ -484,17 +488,16 @@ class CustomMissionLog
 				continue;
 
 			if ( quest.m_CurrentTask.m_CurrentPhase == goal.m_Phase )
-			{
-				var goalDesc:String = "";
-				
+			{				
 				// goal specific timer
 				if (goal.m_ExpireTime > 0)
 				{
 					var timerText:String = timeToString(goal.m_ExpireTime) + " ";
-					goalDesc += timerText;
+					addString(text, fmtGoalTimer, timerText);
+					text += timerText;
 				}
 				
-				goalDesc += com.Utils.LDBFormat.Translate( goal.m_Name );
+				var goalDesc:String = com.Utils.LDBFormat.Translate( goal.m_Name );
 				if (goal.m_RepeatCount > 1 && goal.m_SolvedTimes < goal.m_RepeatCount)
 				{
 					var numDesc:String = " (" + goal.m_SolvedTimes + "/" + goal.m_RepeatCount + ")";

--- a/src/CustomMissionLog.as
+++ b/src/CustomMissionLog.as
@@ -4,6 +4,7 @@ import com.GameInterface.QuestTask;
 import com.GameInterface.Quests;
 import com.GameInterface.UtilsBase;
 import com.GameInterface.DistributedValue;
+import com.GameInterface.Utils;
 import com.Utils.LDBFormat;
 import com.Utils.Point;
 import flash.filters.GlowFilter;
@@ -344,6 +345,27 @@ class CustomMissionLog
 		text += s;
 	}
 	
+	static function timeToString(timeout: Number)
+	{
+		var timerText:String = "[00:00]";
+		
+		var time = Utils.GetServerSyncedTime();
+		var timeLeft = (timeout - time) * 1000;
+		if( timeLeft > 0 )
+		{
+			if( timeLeft > 60*60*1000 )
+			{
+				// Show "hour:min" if more than 1 hour left.
+				timeLeft = timeLeft/60;
+			}
+			
+			//convert timeLeft to "[xx:xx]"
+			timerText = com.Utils.Format.Printf("[%02.0f:%02.0f]", Math.floor(timeLeft / 60000), Math.floor(timeLeft / 1000) % 60 );
+		}
+		
+		return timerText;
+	}
+	
 	// redraw all text
 	public function redraw()
 	{
@@ -432,7 +454,17 @@ class CustomMissionLog
 			"<" + missionType + ">");
 		text += "<" + missionType + "> [L" +
 			quest.m_CurrentTask.m_Difficulty + "] [" +
-			tier + "]\n";
+			tier + "]";
+			
+		// current task global timer
+		if (quest.m_CurrentTask.m_Timeout > 0)
+		{
+			var timerText:String = " " + timeToString(quest.m_CurrentTask.m_Timeout);
+			addString(text, fmtDefault, timerText);
+			text += timerText;
+		}
+		
+		text += "\n";
 
 		// skip global mission description if desc
 		// 0 - all descriptions
@@ -453,7 +485,16 @@ class CustomMissionLog
 
 			if ( quest.m_CurrentTask.m_CurrentPhase == goal.m_Phase )
 			{
-				var goalDesc:String = com.Utils.LDBFormat.Translate( goal.m_Name );
+				var goalDesc:String = "";
+				
+				// goal specific timer
+				if (goal.m_ExpireTime > 0)
+				{
+					var timerText:String = timeToString(goal.m_ExpireTime) + " ";
+					goalDesc += timerText;
+				}
+				
+				goalDesc += com.Utils.LDBFormat.Translate( goal.m_Name );
 				if (goal.m_RepeatCount > 1 && goal.m_SolvedTimes < goal.m_RepeatCount)
 				{
 					var numDesc:String = " (" + goal.m_SolvedTimes + "/" + goal.m_RepeatCount + ")";


### PR DESCRIPTION
Quests can have 2 different type of timers : one for the current task and one for each goal of that task. This PR allows them to be displayed.

I've made the goal specific one display before the goal description. I think it's fine, although giving it a slightly different color might look better.

However, I didn't find a good place to display the current task one. I've put it next to the tier completion in the default format (like this : ``[L50] [1/5] [03:50]``). It's not really visible and should probably be changed, but at least, the feature is here.

Here's a few quests I used to test out those timers :

```
Task timer :
	- The Chrome Steed 1/4 : Ricky Pagan (Kaidan)
	- Dead Rising 4/4 : Moutnefert (City of the Sun God)
Goal timer :
	- Fungal Fireworks 5/5 : Luminita (Shadowy Forest)
	- Digging too deep 1/5 : Moutemouia (City of the Sun God)
	- Mummy Massacre 1/1 : Blood-covered Blade (City of the Sun God)
```